### PR TITLE
Use field mask parser v0.4.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     fmcache (0.1.1)
-      field_mask_parser (~> 0.4.1)
+      field_mask_parser (~> 0.4.2)
 
 GEM
   remote: https://rubygems.org/
@@ -22,7 +22,7 @@ GEM
     coderay (1.1.2)
     concurrent-ruby (1.1.3)
     diff-lcs (1.3)
-    field_mask_parser (0.4.1)
+    field_mask_parser (0.4.2)
     i18n (1.2.0)
       concurrent-ruby (~> 1.0)
     method_source (0.9.2)

--- a/fmcache.gemspec
+++ b/fmcache.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "mock_redis", "~> 0.19"
   spec.add_development_dependency "redis", "~> 4.0"
   spec.add_development_dependency "activerecord", "~> 5.2"
-  spec.add_dependency "field_mask_parser", "~> 0.4.1"
+  spec.add_dependency "field_mask_parser", "~> 0.4.2"
 end

--- a/lib/fmcache/helper.rb
+++ b/lib/fmcache/helper.rb
@@ -4,14 +4,7 @@ module FMCache
       # @param [FieldMaskParser::Node] field_mask
       # @return [<String>]
       def to_fields(field_mask, prefix: [])
-        r = []
-        field_mask.attrs.each do |attr|
-          r << Field.to_s(prefix: prefix, attr: attr)
-        end
-        field_mask.assocs.each do |assoc|
-          r += to_fields(assoc, prefix: prefix + [assoc.name])
-        end
-        r
+        field_mask.to_paths(prefix: prefix, sort: false)
       end
 
       # @param [<Integer>] ids

--- a/lib/fmcache/incomplete_info.rb
+++ b/lib/fmcache/incomplete_info.rb
@@ -9,7 +9,7 @@ module FMCache
 
     def ==(other)
       @ids == other.ids &&
-        @field_mask.to_h == other.field_mask.to_h
+        @field_mask.to_paths == other.field_mask.to_paths
     end
 
     def eql?(other)

--- a/spec/fmcache/engine_spec.rb
+++ b/spec/fmcache/engine_spec.rb
@@ -293,7 +293,7 @@ describe FMCache::Engine do
       it "returns no data" do
         r = engine.fetch(ids: [1], field_mask: field_mask) do |_ids, _field_mask|
           expect(_ids).to eq [1]
-          expect(_field_mask.to_h).to eq field_mask.to_h
+          expect(_field_mask.to_paths).to eq field_mask.to_paths
           [value]
         end
         expect(r).to eq [value]
@@ -331,7 +331,7 @@ describe FMCache::Engine do
         engine.write(values: [cached_value], field_mask: field_mask)
         r = engine.fetch(ids: [1, 2], field_mask: field_mask) do |_ids, _field_mask|
           expect(_ids).to eq [2]
-          expect(_field_mask.to_h).to eq field_mask.to_h
+          expect(_field_mask.to_paths).to eq field_mask.to_paths
           [no_cached_value]
         end
         expect(r).to eq [cached_value, no_cached_value]
@@ -376,7 +376,7 @@ describe FMCache::Engine do
 
         r = engine.fetch(ids: [1, 2], field_mask: field_mask) do |_ids, _field_mask|
           expect(_ids).to eq [2]
-          expect(_field_mask.to_h).to eq fm_parser.call(["name", "id"]).to_h
+          expect(_field_mask.to_paths).to eq ["id", "name"]
           [{ id: 2, name: "Kento" }]
         end
         expect(r).to eq [cached_value, partialy_cached_value]
@@ -431,7 +431,7 @@ describe FMCache::Engine do
 
         r = engine.fetch(ids: [3, 2, 1], field_mask: field_mask) do |_ids, _field_mask|
           expect(_ids).to eq [3, 2]
-          expect(_field_mask.to_h).to eq field_mask.to_h
+          expect(_field_mask.to_paths).to eq field_mask.to_paths
           [partialy_cached_value, no_cached_value]
         end
         expect(r).to eq [no_cached_value, partialy_cached_value, cached_value]
@@ -484,12 +484,12 @@ describe FMCache::Engine do
 
         r = engine.fetch(ids: [1], field_mask: read_field_mask) do |_ids, _field_mask|
           expect(_ids).to eq [1]
-          expect(_field_mask.to_h).to eq fm_parser.call([
+          expect(_field_mask.to_paths).to eq [
             "id",
             "profile.id",
-            "profile.schools.name",
             "profile.schools.id",
-          ]).to_h
+            "profile.schools.name",
+          ]
           [fetched_value]
         end
         expect(r).to eq [


### PR DESCRIPTION
## WHY
field_mask_parser v0.42 supports `FieldMaskParser::Node#to_paths`. We want to use this.

## WHAT
Use field mask parser v0.4.2.