### PR TITLE
Fix #== of IncompleteInfo

### DIFF
--- a/lib/fmcache/incomplete_info.rb
+++ b/lib/fmcache/incomplete_info.rb
@@ -8,7 +8,8 @@ module FMCache
     attr_reader :ids, :field_mask
 
     def ==(other)
-      @ids == other.ids &&
+      self.class == other.class &&
+        @ids == other.ids &&
         @field_mask.to_paths == other.field_mask.to_paths
     end
 


### PR DESCRIPTION
## WHY
In current implementation, `FMCache::IncompleteInfo#==` throws an error when compared with objects other than `FMCache::IncompleteInfo`

## WHAT
Fixed.