### PR TITLE
Fix decoding and encoding bug of has_one association

### DIFF
--- a/lib/fmcache/decoder/value_decoder/data.rb
+++ b/lib/fmcache/decoder/value_decoder/data.rb
@@ -53,7 +53,11 @@ module FMCache
             r[name] = item.value
           end
           @has_ones.each do |name, data|
-            r[name] = data.to_h
+            if data
+              r[name] = data.to_h
+            else
+              r[name] = nil
+            end
           end
           @has_manies.each do |name, data_list|
             r[name] = data_list.map(&:to_h)

--- a/lib/fmcache/encoder.rb
+++ b/lib/fmcache/encoder.rb
@@ -10,10 +10,9 @@ module FMCache
 
       r = {}
       values.each do |value|
-        h = {}
-        fields.each do |f|
-          h[f] = []
-        end
+        # NOTE: `[]` is the default value of each field.
+        h = fields.map { |f| [f, []] }.to_h
+
         h.merge! encode_one(value, field_mask)
 
         id = value.fetch(:id)

--- a/lib/fmcache/encoder/itemizer.rb
+++ b/lib/fmcache/encoder/itemizer.rb
@@ -29,10 +29,11 @@ module FMCache
         end
 
         field_mask.has_ones.each do |assoc|
-          v = value[assoc.name] || {}
-          p = prefix + [assoc.name]
-
-          traverse!(value: v, field_mask: assoc, prefix: p, p_id: id)
+          v = value[assoc.name]
+          if v  # NOTE: Proceed only when value exists
+            p = prefix + [assoc.name]
+            traverse!(value: v, field_mask: assoc, prefix: p, p_id: id)
+          end
         end
 
         field_mask.has_manies.each do |assoc|


### PR DESCRIPTION
## WHY
In current implementation, the `nil` value of the `has_one` association is encoded to `"[{\"value\":null,\"id\":null,\"p_id\":1}]"` and the encoded value is decoded to `{ id: nil }`.
This is not the desired behavior.

## WHAT
Fixed this.
From now, we encode `nil` to `[]` and decode it to `nil`.