### PR TITLE
Bump up activesupport and others

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,26 +7,25 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (5.2.2)
-      activesupport (= 5.2.2)
-    activerecord (5.2.2)
-      activemodel (= 5.2.2)
-      activesupport (= 5.2.2)
-      arel (>= 9.0)
-    activesupport (5.2.2)
+    activemodel (6.0.3.1)
+      activesupport (= 6.0.3.1)
+    activerecord (6.0.3.1)
+      activemodel (= 6.0.3.1)
+      activesupport (= 6.0.3.1)
+    activesupport (6.0.3.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    arel (9.0.0)
+      zeitwerk (~> 2.2, >= 2.2.2)
     coderay (1.1.2)
-    concurrent-ruby (1.1.3)
+    concurrent-ruby (1.1.6)
     diff-lcs (1.3)
     field_mask_parser (0.4.3)
-    i18n (1.2.0)
+    i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     method_source (0.9.2)
-    minitest (5.11.3)
+    minitest (5.14.1)
     mock_redis (0.19.0)
     pry (0.12.2)
       coderay (~> 1.1.0)
@@ -47,14 +46,15 @@ GEM
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
     thread_safe (0.3.6)
-    tzinfo (1.2.5)
+    tzinfo (1.2.7)
       thread_safe (~> 0.1)
+    zeitwerk (2.3.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord (~> 5.2)
+  activerecord
   bundler (~> 1.16)
   fmcache!
   mock_redis (~> 0.19)
@@ -64,4 +64,4 @@ DEPENDENCIES
   rspec (~> 3.8)
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/fmcache.gemspec
+++ b/fmcache.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry", "~> 0.11"
   spec.add_development_dependency "mock_redis", "~> 0.19"
   spec.add_development_dependency "redis", "~> 4.0"
-  spec.add_development_dependency "activerecord", "~> 5.2"
+  spec.add_development_dependency "activerecord"
   spec.add_dependency "field_mask_parser", "~> 0.4.3"
 end


### PR DESCRIPTION
## WHY
A vulnerability was found in activesupport https://github.com/advisories/GHSA-2p68-f74v-9wc6

## WHAT
Bump up activesupport and others.
This only affects the development environment.